### PR TITLE
feat(auth): Add refresh token functionality for user authentication

### DIFF
--- a/prisma/migrations/20250512184641_add_refresh_tokens/migration.sql
+++ b/prisma/migrations/20250512184641_add_refresh_tokens/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "RefreshToken" (
+    "id" SERIAL NOT NULL,
+    "token" TEXT NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RefreshToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RefreshToken_token_key" ON "RefreshToken"("token");
+
+-- AddForeignKey
+ALTER TABLE "RefreshToken" ADD CONSTRAINT "RefreshToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,16 +14,27 @@ datasource db {
 }
 
 model User {
-  id         Int      @id @default(autoincrement())
-  email      String   @unique
-  name       String
-  password   String? // Nullable because OAuth users won't have a password
-  photoUrl   String? // Profile picture URL for OAuth users
-  role       Role     @default(USER)
-  provider   Provider @default(LOCAL)
-  providerId String? // External ID for OAuth users
-  createdAt  DateTime @default(now())
-  updatedAt  DateTime @updatedAt
+  id            Int            @id @default(autoincrement())
+  email         String         @unique
+  name          String
+  password      String? // Nullable because OAuth users won't have a password
+  photoUrl      String? // Profile picture URL for OAuth users
+  role          Role           @default(USER)
+  provider      Provider       @default(LOCAL)
+  providerId    String? // External ID for OAuth users
+  createdAt     DateTime       @default(now())
+  updatedAt     DateTime       @updatedAt
+  refreshTokens RefreshToken[]
+}
+
+model RefreshToken {
+  id        Int      @id @default(autoincrement())
+  token     String   @unique
+  userId    Int
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  expiresAt DateTime
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 }
 
 enum Role {

--- a/src/modules/auth/application/services/__tests__/auth.service.spec.ts
+++ b/src/modules/auth/application/services/__tests__/auth.service.spec.ts
@@ -32,6 +32,16 @@ describe('AuthService', () => {
     updatedAt: new Date(),
   };
 
+  const mockRefreshToken = {
+    id: 1,
+    token: 'test-refresh-token',
+    userId: 1,
+    expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000), // 7 days from now
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    user: mockUser,
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -44,6 +54,11 @@ describe('AuthService', () => {
               findFirst: jest.fn(),
               create: jest.fn(),
               update: jest.fn(),
+            },
+            refreshToken: {
+              create: jest.fn(),
+              findUnique: jest.fn(),
+              delete: jest.fn(),
             },
           },
         },
@@ -212,7 +227,7 @@ describe('AuthService', () => {
   });
 
   describe('login', () => {
-    it('should return user and token', () => {
+    it('should return user, access token and refresh token', async () => {
       const authUser: AuthUser = {
         id: 1,
         email: 'test@example.com',
@@ -222,7 +237,13 @@ describe('AuthService', () => {
         provider: Provider.LOCAL,
       };
 
-      const result = authService.login(authUser);
+      const createRefreshTokenSpy = jest.spyOn(
+        prismaService.refreshToken,
+        'create',
+      );
+      createRefreshTokenSpy.mockResolvedValue(mockRefreshToken);
+
+      const result = await authService.login(authUser);
 
       const signSpy = jest.spyOn(jwtService, 'sign');
       expect(signSpy).toHaveBeenCalledWith({
@@ -233,6 +254,7 @@ describe('AuthService', () => {
       expect(result).toEqual({
         user: authUser,
         accessToken: 'test-token',
+        refreshToken: mockRefreshToken.token,
       });
     });
   });
@@ -244,7 +266,7 @@ describe('AuthService', () => {
       password: 'password123',
     };
 
-    it('should register a new user and return token', async () => {
+    it('should register a new user and return tokens', async () => {
       const createdUser: User = {
         ...mockUser,
         email: registerDto.email,
@@ -256,6 +278,12 @@ describe('AuthService', () => {
 
       const createSpy = jest.spyOn(prismaService.user, 'create');
       createSpy.mockResolvedValue(createdUser);
+
+      const createRefreshTokenSpy = jest.spyOn(
+        prismaService.refreshToken,
+        'create',
+      );
+      createRefreshTokenSpy.mockResolvedValue(mockRefreshToken);
 
       (bcrypt.hash as jest.Mock).mockResolvedValue('hashed-password');
 
@@ -280,6 +308,7 @@ describe('AuthService', () => {
       expect(result).toEqual({
         user: expectedUser,
         accessToken: 'test-token',
+        refreshToken: mockRefreshToken.token,
       });
     });
 
@@ -290,6 +319,84 @@ describe('AuthService', () => {
       await expect(authService.register(registerDto)).rejects.toThrow(
         new UnauthorizedException('El email ya está registrado'),
       );
+    });
+  });
+
+  describe('refreshTokens', () => {
+    it('should return new access and refresh tokens when valid', async () => {
+      const findUniqueSpy = jest.spyOn(
+        prismaService.refreshToken,
+        'findUnique',
+      );
+      findUniqueSpy.mockResolvedValue(mockRefreshToken);
+
+      const deleteSpy = jest.spyOn(prismaService.refreshToken, 'delete');
+      deleteSpy.mockResolvedValue(mockRefreshToken);
+
+      const createRefreshTokenSpy = jest.spyOn(
+        prismaService.refreshToken,
+        'create',
+      );
+      createRefreshTokenSpy.mockResolvedValue({
+        ...mockRefreshToken,
+        token: 'new-refresh-token',
+      });
+
+      const result = await authService.refreshTokens('test-refresh-token');
+
+      expect(findUniqueSpy).toHaveBeenCalledWith({
+        where: { token: 'test-refresh-token' },
+        include: { user: true },
+      });
+      expect(deleteSpy).toHaveBeenCalledWith({
+        where: { token: 'test-refresh-token' },
+      });
+      expect(result).toEqual({
+        accessToken: 'test-token',
+        refreshToken: 'new-refresh-token',
+      });
+    });
+
+    it('should throw UnauthorizedException when refresh token is not found', async () => {
+      const findUniqueSpy = jest.spyOn(
+        prismaService.refreshToken,
+        'findUnique',
+      );
+      findUniqueSpy.mockResolvedValue(null);
+
+      await expect(authService.refreshTokens('invalid-token')).rejects.toThrow(
+        new UnauthorizedException('Invalid or expired refresh token'),
+      );
+    });
+
+    it('should throw UnauthorizedException when refresh token is expired', async () => {
+      const expiredToken = {
+        ...mockRefreshToken,
+        expiresAt: new Date(Date.now() - 1000), // 1 second ago
+      };
+
+      const findUniqueSpy = jest.spyOn(
+        prismaService.refreshToken,
+        'findUnique',
+      );
+      findUniqueSpy.mockResolvedValue(expiredToken);
+
+      await expect(authService.refreshTokens('expired-token')).rejects.toThrow(
+        new UnauthorizedException('Invalid or expired refresh token'),
+      );
+    });
+  });
+
+  describe('logout', () => {
+    it('should delete the refresh token', async () => {
+      const deleteSpy = jest.spyOn(prismaService.refreshToken, 'delete');
+      deleteSpy.mockResolvedValue(mockRefreshToken);
+
+      await authService.logout('test-refresh-token');
+
+      expect(deleteSpy).toHaveBeenCalledWith({
+        where: { token: 'test-refresh-token' },
+      });
     });
   });
 });

--- a/src/modules/auth/application/services/auth.service.ts
+++ b/src/modules/auth/application/services/auth.service.ts
@@ -7,6 +7,7 @@ import * as bcrypt from 'bcryptjs';
 import { User } from '@prisma/client';
 import { Provider, Role } from '@prisma/client';
 import { AuthUser } from '../../domain/interfaces/user.interface';
+import { randomBytes } from 'crypto';
 
 @Injectable()
 export class AuthService {
@@ -72,12 +73,40 @@ export class AuthService {
     return user;
   }
 
-  login(user: AuthUser) {
+  private generateRefreshToken(): string {
+    return randomBytes(40).toString('hex');
+  }
+
+  private async createRefreshToken(userId: number): Promise<string> {
+    const refreshToken = this.generateRefreshToken();
+    const expiresAt = new Date();
+    expiresAt.setDate(expiresAt.getDate() + 7); // 7 days expiration
+
+    await this.prisma.refreshToken.create({
+      data: {
+        token: refreshToken,
+        userId,
+        expiresAt,
+      },
+    });
+
+    return refreshToken;
+  }
+
+  private async removeRefreshToken(token: string): Promise<void> {
+    await this.prisma.refreshToken.delete({
+      where: { token },
+    });
+  }
+
+  async login(user: AuthUser) {
     const payload = {
       sub: user.id,
       email: user.email,
       role: user.role,
     };
+
+    const refreshToken = await this.createRefreshToken(user.id);
 
     return {
       user: {
@@ -89,6 +118,7 @@ export class AuthService {
         provider: user.provider,
       },
       accessToken: this.jwtService.sign(payload),
+      refreshToken,
     };
   }
 
@@ -120,9 +150,44 @@ export class AuthService {
       role: result.role,
     };
 
+    const refreshToken = await this.createRefreshToken(user.id);
+
     return {
       user: result,
       accessToken: this.jwtService.sign(payload),
+      refreshToken,
     };
+  }
+
+  async refreshTokens(refreshToken: string) {
+    const token = await this.prisma.refreshToken.findUnique({
+      where: { token: refreshToken },
+      include: { user: true },
+    });
+
+    if (!token || token.expiresAt < new Date()) {
+      throw new UnauthorizedException('Invalid or expired refresh token');
+    }
+
+    // Remove the used refresh token
+    await this.removeRefreshToken(refreshToken);
+
+    const payload = {
+      sub: token.user.id,
+      email: token.user.email,
+      role: token.user.role,
+    };
+
+    // Generate new tokens
+    const newRefreshToken = await this.createRefreshToken(token.user.id);
+
+    return {
+      accessToken: this.jwtService.sign(payload),
+      refreshToken: newRefreshToken,
+    };
+  }
+
+  async logout(refreshToken: string) {
+    await this.removeRefreshToken(refreshToken);
   }
 }

--- a/src/modules/auth/infrastructure/controllers/__tests__/auth.controller.spec.ts
+++ b/src/modules/auth/infrastructure/controllers/__tests__/auth.controller.spec.ts
@@ -3,6 +3,7 @@ import { Role, Provider } from '@prisma/client';
 import { AuthController } from '../auth.controller';
 import { AuthService } from '../../../application/services/auth.service';
 import { RegisterDto } from '../../dto/register.dto';
+import { RefreshTokenDto } from '../../dto/refresh-token.dto';
 import { AuthUser } from '../../../domain/interfaces/user.interface';
 
 // Create RequestWithUser interface
@@ -37,6 +38,7 @@ describe('AuthController', () => {
       updatedAt: new Date(),
     },
     accessToken: 'test-token',
+    refreshToken: 'test-refresh-token',
   };
 
   // Create a mock login response that matches expected type
@@ -50,6 +52,12 @@ describe('AuthController', () => {
       provider: mockUser.provider,
     },
     accessToken: 'test-token',
+    refreshToken: 'test-refresh-token',
+  };
+
+  const mockRefreshResponse = {
+    accessToken: 'new-test-token',
+    refreshToken: 'new-test-refresh-token',
   };
 
   beforeEach(async () => {
@@ -62,6 +70,8 @@ describe('AuthController', () => {
             register: jest.fn(),
             login: jest.fn(),
             validateUser: jest.fn(),
+            refreshTokens: jest.fn(),
+            logout: jest.fn(),
           },
         },
       ],
@@ -94,16 +104,50 @@ describe('AuthController', () => {
   });
 
   describe('login', () => {
-    it('should login a user', () => {
+    it('should login a user', async () => {
       const req = { user: mockUser } as RequestWithUser;
 
       const loginSpy = jest.spyOn(authService, 'login');
-      loginSpy.mockReturnValue(mockLoginResponse);
+      loginSpy.mockResolvedValue(mockLoginResponse);
 
-      const result = controller.login(req);
+      const result = await controller.login(req);
 
       expect(loginSpy).toHaveBeenCalledWith(mockUser);
       expect(result).toEqual(mockLoginResponse);
+    });
+  });
+
+  describe('refreshTokens', () => {
+    it('should refresh tokens', async () => {
+      const refreshTokenDto: RefreshTokenDto = {
+        refreshToken: 'test-refresh-token',
+      };
+
+      const refreshTokensSpy = jest.spyOn(authService, 'refreshTokens');
+      refreshTokensSpy.mockResolvedValue(mockRefreshResponse);
+
+      const result = await controller.refreshTokens(refreshTokenDto);
+
+      expect(refreshTokensSpy).toHaveBeenCalledWith(
+        refreshTokenDto.refreshToken,
+      );
+      expect(result).toEqual(mockRefreshResponse);
+    });
+  });
+
+  describe('logout', () => {
+    it('should logout user', async () => {
+      const refreshTokenDto: RefreshTokenDto = {
+        refreshToken: 'test-refresh-token',
+      };
+
+      const logoutSpy = jest.spyOn(authService, 'logout');
+      logoutSpy.mockResolvedValue(undefined);
+
+      const result = await controller.logout(refreshTokenDto);
+
+      expect(logoutSpy).toHaveBeenCalledWith(refreshTokenDto.refreshToken);
+      expect(result).toEqual({ message: 'Logged out successfully' });
     });
   });
 
@@ -138,25 +182,25 @@ describe('AuthController', () => {
   });
 
   describe('OAuth callbacks', () => {
-    it('should login a user after Google authentication', () => {
+    it('should login a user after Google authentication', async () => {
       const req = { user: mockUser } as RequestWithUser;
 
       const loginSpy = jest.spyOn(authService, 'login');
-      loginSpy.mockReturnValue(mockLoginResponse);
+      loginSpy.mockResolvedValue(mockLoginResponse);
 
-      const result = controller.googleAuthCallback(req);
+      const result = await controller.googleAuthCallback(req);
 
       expect(loginSpy).toHaveBeenCalledWith(mockUser);
       expect(result).toEqual(mockLoginResponse);
     });
 
-    it('should login a user after Apple authentication', () => {
+    it('should login a user after Apple authentication', async () => {
       const req = { user: mockUser } as RequestWithUser;
 
       const loginSpy = jest.spyOn(authService, 'login');
-      loginSpy.mockReturnValue(mockLoginResponse);
+      loginSpy.mockResolvedValue(mockLoginResponse);
 
-      const result = controller.appleAuthCallback(req);
+      const result = await controller.appleAuthCallback(req);
 
       expect(loginSpy).toHaveBeenCalledWith(mockUser);
       expect(result).toEqual(mockLoginResponse);

--- a/src/modules/auth/infrastructure/controllers/auth.controller.ts
+++ b/src/modules/auth/infrastructure/controllers/auth.controller.ts
@@ -2,6 +2,7 @@ import { Body, Controller, Get, Post, Req, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { AuthService } from '../../application/services/auth.service';
 import { RegisterDto } from '../dto/register.dto';
+import { RefreshTokenDto } from '../dto/refresh-token.dto';
 import { Roles } from '../decorators/roles.decorator';
 import { RolesGuard } from '../guards/roles.guard';
 import { Role } from '@prisma/client';
@@ -70,5 +71,16 @@ export class AuthController {
   @UseGuards(AuthGuard('jwt'))
   getProfile(@Req() req: RequestWithUser) {
     return req.user;
+  }
+
+  @Post('refresh')
+  async refreshTokens(@Body() refreshTokenDto: RefreshTokenDto) {
+    return this.authService.refreshTokens(refreshTokenDto.refreshToken);
+  }
+
+  @Post('logout')
+  async logout(@Body() refreshTokenDto: RefreshTokenDto) {
+    await this.authService.logout(refreshTokenDto.refreshToken);
+    return { message: 'Logged out successfully' };
   }
 }

--- a/src/modules/auth/infrastructure/dto/refresh-token.dto.ts
+++ b/src/modules/auth/infrastructure/dto/refresh-token.dto.ts
@@ -1,0 +1,7 @@
+import { IsString, IsNotEmpty } from 'class-validator';
+
+export class RefreshTokenDto {
+  @IsString()
+  @IsNotEmpty()
+  refreshToken: string;
+}


### PR DESCRIPTION
# feat(auth): Add refresh token functionality for user authentication

## Description

- Introduced a new RefreshToken model in the Prisma schema to manage refresh tokens.
- Implemented methods in AuthService for generating, creating, and removing refresh tokens.
- Updated login method to return a refresh token alongside the access token.
- Added refresh and logout endpoints in AuthController to handle token operations.
- Created a RefreshTokenDto for validating refresh token requests.

This enhancement improves the authentication flow by allowing users to obtain new access tokens without re-entering credentials.

## Type of Changes

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🛠️ Code refactor or improvement
- [ ] 🧪 Test enhancement
- [ ] 📖 Documentation update

## Checklist

- [x] Code compiles and runs correctly
- [x] Linting and formatting rules have been followed (`eslint`, `prettier`, etc.)
- [x] Corresponding tests have been added and/or updated
- [ ] Documentation has been updated (if applicable)
- [x] The PR title is clear and uses proper formatting
- [x] Commits are clean, with descriptive messages