### PR TITLE
feat(auth): Add profile update and password change functionality

### DIFF
--- a/src/modules/auth/application/services/__tests__/auth.service.spec.ts
+++ b/src/modules/auth/application/services/__tests__/auth.service.spec.ts
@@ -2,12 +2,18 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { JwtService } from '@nestjs/jwt';
 import { AuthService } from '../auth.service';
 import { PrismaService } from '../../../../prisma/prisma.service';
-import { UnauthorizedException } from '@nestjs/common';
+import {
+  UnauthorizedException,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
 import { Provider, Role, User } from '@prisma/client';
 import { RegisterDto } from '../../../infrastructure/dto/register.dto';
 import { OAuthLoginDto } from '../../../infrastructure/dto/oauth-login.dto';
 import * as bcrypt from 'bcryptjs';
 import { AuthUser } from '../../../domain/interfaces/user.interface';
+import { UpdateProfileDto } from '../../../infrastructure/dto/update-profile.dto';
+import { ChangePasswordDto } from '../../../infrastructure/dto/change-password.dto';
 
 jest.mock('bcryptjs', () => ({
   compare: jest.fn(),
@@ -237,11 +243,10 @@ describe('AuthService', () => {
         provider: Provider.LOCAL,
       };
 
-      const createRefreshTokenSpy = jest.spyOn(
-        prismaService.refreshToken,
-        'create',
-      );
-      createRefreshTokenSpy.mockResolvedValue(mockRefreshToken);
+      // Mock the private method that generates the refresh token
+      jest
+        .spyOn<any, any>(authService, 'createRefreshToken')
+        .mockResolvedValue('test-refresh-token');
 
       const result = await authService.login(authUser);
 
@@ -254,7 +259,7 @@ describe('AuthService', () => {
       expect(result).toEqual({
         user: authUser,
         accessToken: 'test-token',
-        refreshToken: mockRefreshToken.token,
+        refreshToken: 'test-refresh-token',
       });
     });
   });
@@ -279,11 +284,10 @@ describe('AuthService', () => {
       const createSpy = jest.spyOn(prismaService.user, 'create');
       createSpy.mockResolvedValue(createdUser);
 
-      const createRefreshTokenSpy = jest.spyOn(
-        prismaService.refreshToken,
-        'create',
-      );
-      createRefreshTokenSpy.mockResolvedValue(mockRefreshToken);
+      // Mock the private method that generates the refresh token
+      jest
+        .spyOn<any, any>(authService, 'createRefreshToken')
+        .mockResolvedValue('test-refresh-token');
 
       (bcrypt.hash as jest.Mock).mockResolvedValue('hashed-password');
 
@@ -308,7 +312,7 @@ describe('AuthService', () => {
       expect(result).toEqual({
         user: expectedUser,
         accessToken: 'test-token',
-        refreshToken: mockRefreshToken.token,
+        refreshToken: 'test-refresh-token',
       });
     });
 
@@ -333,14 +337,10 @@ describe('AuthService', () => {
       const deleteSpy = jest.spyOn(prismaService.refreshToken, 'delete');
       deleteSpy.mockResolvedValue(mockRefreshToken);
 
-      const createRefreshTokenSpy = jest.spyOn(
-        prismaService.refreshToken,
-        'create',
-      );
-      createRefreshTokenSpy.mockResolvedValue({
-        ...mockRefreshToken,
-        token: 'new-refresh-token',
-      });
+      // Mock the private method that generates the refresh token
+      jest
+        .spyOn<any, any>(authService, 'createRefreshToken')
+        .mockResolvedValue('new-refresh-token');
 
       const result = await authService.refreshTokens('test-refresh-token');
 
@@ -397,6 +397,193 @@ describe('AuthService', () => {
       expect(deleteSpy).toHaveBeenCalledWith({
         where: { token: 'test-refresh-token' },
       });
+    });
+  });
+
+  describe('updateProfile', () => {
+    const updateProfileDto: UpdateProfileDto = {
+      name: 'Updated Name',
+      email: 'updated@example.com',
+      photoUrl: 'https://updated-photo-url.com',
+    };
+
+    it('should update user profile successfully', async () => {
+      const userId = 1;
+      const updatedUser: User = {
+        ...mockUser,
+        name: updateProfileDto.name!,
+        email: updateProfileDto.email!,
+        photoUrl: updateProfileDto.photoUrl || null,
+      };
+
+      const findUniqueSpy = jest.spyOn(prismaService.user, 'findUnique');
+      findUniqueSpy.mockResolvedValueOnce(mockUser); // First call to check if user exists
+
+      // No existing user with updated email
+      findUniqueSpy.mockResolvedValueOnce(null);
+
+      const updateSpy = jest.spyOn(prismaService.user, 'update');
+      updateSpy.mockResolvedValue(updatedUser);
+
+      const result = await authService.updateProfile(userId, updateProfileDto);
+
+      expect(findUniqueSpy).toHaveBeenCalledWith({
+        where: { id: userId },
+      });
+      expect(updateSpy).toHaveBeenCalledWith({
+        where: { id: userId },
+        data: updateProfileDto,
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { password: _, ...expectedUser } = updatedUser;
+      expect(result).toEqual(expectedUser);
+    });
+
+    it('should throw NotFoundException when user is not found', async () => {
+      const userId = 999;
+      const findUniqueSpy = jest.spyOn(prismaService.user, 'findUnique');
+      findUniqueSpy.mockResolvedValue(null);
+
+      await expect(
+        authService.updateProfile(userId, updateProfileDto),
+      ).rejects.toThrow(new NotFoundException('Usuario no encontrado'));
+    });
+
+    it('should throw BadRequestException when email is already in use', async () => {
+      const userId = 1;
+      const existingUser = { ...mockUser, id: 2 }; // Different user with the same email
+
+      const findUniqueSpy = jest.spyOn(prismaService.user, 'findUnique');
+      findUniqueSpy.mockResolvedValueOnce(mockUser); // First call to check if user exists
+      findUniqueSpy.mockResolvedValueOnce(existingUser); // Second call to check if email exists
+
+      await expect(
+        authService.updateProfile(userId, {
+          email: 'updated@example.com',
+        }),
+      ).rejects.toThrow(new BadRequestException('El email ya está en uso'));
+    });
+
+    it('should only update provided fields', async () => {
+      const userId = 1;
+      const partialUpdateDto: UpdateProfileDto = {
+        name: 'Updated Name',
+      };
+
+      const updatedUser: User = {
+        ...mockUser,
+        name: partialUpdateDto.name!,
+      };
+
+      const findUniqueSpy = jest.spyOn(prismaService.user, 'findUnique');
+      findUniqueSpy.mockResolvedValue(mockUser);
+
+      const updateSpy = jest.spyOn(prismaService.user, 'update');
+      updateSpy.mockResolvedValue(updatedUser);
+
+      const result = await authService.updateProfile(userId, partialUpdateDto);
+
+      expect(updateSpy).toHaveBeenCalledWith({
+        where: { id: userId },
+        data: partialUpdateDto,
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { password: _, ...expectedUser } = updatedUser;
+      expect(result).toEqual(expectedUser);
+    });
+  });
+
+  describe('changePassword', () => {
+    const changePasswordDto: ChangePasswordDto = {
+      currentPassword: 'current-password',
+      newPassword: 'new-password',
+    };
+
+    it('should change password successfully', async () => {
+      const userId = 1;
+
+      const findUniqueSpy = jest.spyOn(prismaService.user, 'findUnique');
+      findUniqueSpy.mockResolvedValue(mockUser);
+
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+      (bcrypt.hash as jest.Mock).mockResolvedValue('new-hashed-password');
+
+      const updateSpy = jest.spyOn(prismaService.user, 'update');
+      updateSpy.mockResolvedValue({
+        ...mockUser,
+        password: 'new-hashed-password',
+      });
+
+      const result = await authService.changePassword(
+        userId,
+        changePasswordDto,
+      );
+
+      expect(findUniqueSpy).toHaveBeenCalledWith({
+        where: { id: userId },
+      });
+      expect(bcrypt.compare).toHaveBeenCalledWith(
+        changePasswordDto.currentPassword,
+        mockUser.password,
+      );
+      expect(bcrypt.hash).toHaveBeenCalledWith(
+        changePasswordDto.newPassword,
+        10,
+      );
+      expect(updateSpy).toHaveBeenCalledWith({
+        where: { id: userId },
+        data: { password: 'new-hashed-password' },
+      });
+      expect(result).toEqual({
+        message: 'Contraseña actualizada exitosamente',
+      });
+    });
+
+    it('should throw NotFoundException when user is not found', async () => {
+      const userId = 999;
+      const findUniqueSpy = jest.spyOn(prismaService.user, 'findUnique');
+      findUniqueSpy.mockResolvedValue(null);
+
+      await expect(
+        authService.changePassword(userId, changePasswordDto),
+      ).rejects.toThrow(new NotFoundException('Usuario no encontrado'));
+    });
+
+    it('should throw BadRequestException for OAuth users without password', async () => {
+      const userId = 1;
+      const oauthUser: User = {
+        ...mockUser,
+        password: null,
+        provider: Provider.GOOGLE,
+      };
+
+      const findUniqueSpy = jest.spyOn(prismaService.user, 'findUnique');
+      findUniqueSpy.mockResolvedValue(oauthUser);
+
+      await expect(
+        authService.changePassword(userId, changePasswordDto),
+      ).rejects.toThrow(
+        new BadRequestException(
+          'No es posible cambiar la contraseña para usuarios de proveedores externos',
+        ),
+      );
+    });
+
+    it('should throw UnauthorizedException when current password is incorrect', async () => {
+      const userId = 1;
+
+      const findUniqueSpy = jest.spyOn(prismaService.user, 'findUnique');
+      findUniqueSpy.mockResolvedValue(mockUser);
+
+      (bcrypt.compare as jest.Mock).mockResolvedValue(false);
+
+      await expect(
+        authService.changePassword(userId, changePasswordDto),
+      ).rejects.toThrow(
+        new UnauthorizedException('La contraseña actual es incorrecta'),
+      );
     });
   });
 });

--- a/src/modules/auth/application/services/auth.service.ts
+++ b/src/modules/auth/application/services/auth.service.ts
@@ -1,4 +1,9 @@
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import {
+  Injectable,
+  UnauthorizedException,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { RegisterDto } from '../../infrastructure/dto/register.dto';
@@ -8,6 +13,8 @@ import { User } from '@prisma/client';
 import { Provider, Role } from '@prisma/client';
 import { AuthUser } from '../../domain/interfaces/user.interface';
 import { randomBytes } from 'crypto';
+import { UpdateProfileDto } from '../../infrastructure/dto/update-profile.dto';
+import { ChangePasswordDto } from '../../infrastructure/dto/change-password.dto';
 
 @Injectable()
 export class AuthService {
@@ -189,5 +196,73 @@ export class AuthService {
 
   async logout(refreshToken: string) {
     await this.removeRefreshToken(refreshToken);
+  }
+
+  async updateProfile(userId: number, updateProfileDto: UpdateProfileDto) {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+    });
+
+    if (!user) {
+      throw new NotFoundException('Usuario no encontrado');
+    }
+
+    // Check if email is being updated and if it's already in use by another user
+    if (updateProfileDto.email && updateProfileDto.email !== user.email) {
+      const emailExists = await this.prisma.user.findUnique({
+        where: { email: updateProfileDto.email },
+      });
+
+      if (emailExists) {
+        throw new BadRequestException('El email ya está en uso');
+      }
+    }
+
+    const updatedUser = await this.prisma.user.update({
+      where: { id: userId },
+      data: updateProfileDto,
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { password: _, ...result } = updatedUser;
+    return result;
+  }
+
+  async changePassword(userId: number, changePasswordDto: ChangePasswordDto) {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+    });
+
+    if (!user) {
+      throw new NotFoundException('Usuario no encontrado');
+    }
+
+    // For OAuth users that don't have a password
+    if (!user.password) {
+      throw new BadRequestException(
+        'No es posible cambiar la contraseña para usuarios de proveedores externos',
+      );
+    }
+
+    const isCurrentPasswordValid = await bcrypt.compare(
+      changePasswordDto.currentPassword,
+      user.password,
+    );
+
+    if (!isCurrentPasswordValid) {
+      throw new UnauthorizedException('La contraseña actual es incorrecta');
+    }
+
+    const hashedNewPassword = await bcrypt.hash(
+      changePasswordDto.newPassword,
+      10,
+    );
+
+    await this.prisma.user.update({
+      where: { id: userId },
+      data: { password: hashedNewPassword },
+    });
+
+    return { message: 'Contraseña actualizada exitosamente' };
   }
 }

--- a/src/modules/auth/infrastructure/controllers/__tests__/auth.controller.spec.ts
+++ b/src/modules/auth/infrastructure/controllers/__tests__/auth.controller.spec.ts
@@ -1,10 +1,12 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { Role, Provider } from '@prisma/client';
-import { AuthController } from '../auth.controller';
+import { AuthController } from '../../controllers/auth.controller';
 import { AuthService } from '../../../application/services/auth.service';
 import { RegisterDto } from '../../dto/register.dto';
 import { RefreshTokenDto } from '../../dto/refresh-token.dto';
 import { AuthUser } from '../../../domain/interfaces/user.interface';
+import { UpdateProfileDto } from '../../dto/update-profile.dto';
+import { ChangePasswordDto } from '../../dto/change-password.dto';
 
 // Create RequestWithUser interface
 interface RequestWithUser extends Request {
@@ -72,6 +74,8 @@ describe('AuthController', () => {
             validateUser: jest.fn(),
             refreshTokens: jest.fn(),
             logout: jest.fn(),
+            updateProfile: jest.fn(),
+            changePassword: jest.fn(),
           },
         },
       ],
@@ -204,6 +208,66 @@ describe('AuthController', () => {
 
       expect(loginSpy).toHaveBeenCalledWith(mockUser);
       expect(result).toEqual(mockLoginResponse);
+    });
+  });
+
+  describe('updateProfile', () => {
+    it('should update the user profile', async () => {
+      const req = { user: mockUser } as RequestWithUser;
+      const updateProfileDto: UpdateProfileDto = {
+        name: 'Updated Name',
+        email: 'updated@example.com',
+        photoUrl: 'https://updated-photo-url.com',
+      };
+
+      // Mocked response from service with required User properties
+      const updatedUser = {
+        id: mockUser.id,
+        name: updateProfileDto.name!,
+        email: updateProfileDto.email!,
+        photoUrl: updateProfileDto.photoUrl || null,
+        role: mockUser.role,
+        provider: mockUser.provider,
+        providerId: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      const updateProfileSpy = jest.spyOn(authService, 'updateProfile');
+      updateProfileSpy.mockResolvedValue(updatedUser);
+
+      const result = await controller.updateProfile(req, updateProfileDto);
+
+      expect(updateProfileSpy).toHaveBeenCalledWith(
+        mockUser.id,
+        updateProfileDto,
+      );
+      expect(result).toEqual(updatedUser);
+    });
+  });
+
+  describe('changePassword', () => {
+    it('should change the user password', async () => {
+      const req = { user: mockUser } as RequestWithUser;
+      const changePasswordDto: ChangePasswordDto = {
+        currentPassword: 'current-password',
+        newPassword: 'new-password',
+      };
+
+      const serviceResponse = {
+        message: 'Contraseña actualizada exitosamente',
+      };
+
+      const changePasswordSpy = jest.spyOn(authService, 'changePassword');
+      changePasswordSpy.mockResolvedValue(serviceResponse);
+
+      const result = await controller.changePassword(req, changePasswordDto);
+
+      expect(changePasswordSpy).toHaveBeenCalledWith(
+        mockUser.id,
+        changePasswordDto,
+      );
+      expect(result).toEqual(serviceResponse);
     });
   });
 });

--- a/src/modules/auth/infrastructure/controllers/auth.controller.ts
+++ b/src/modules/auth/infrastructure/controllers/auth.controller.ts
@@ -1,4 +1,12 @@
-import { Body, Controller, Get, Post, Req, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Post,
+  Req,
+  UseGuards,
+  Patch,
+} from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { AuthService } from '../../application/services/auth.service';
 import { RegisterDto } from '../dto/register.dto';
@@ -7,6 +15,8 @@ import { Roles } from '../decorators/roles.decorator';
 import { RolesGuard } from '../guards/roles.guard';
 import { Role } from '@prisma/client';
 import { AuthUser } from '../../domain/interfaces/user.interface';
+import { UpdateProfileDto } from '../dto/update-profile.dto';
+import { ChangePasswordDto } from '../dto/change-password.dto';
 
 interface RequestWithUser extends Request {
   user: AuthUser;
@@ -71,6 +81,24 @@ export class AuthController {
   @UseGuards(AuthGuard('jwt'))
   getProfile(@Req() req: RequestWithUser) {
     return req.user;
+  }
+
+  @Patch('profile')
+  @UseGuards(AuthGuard('jwt'))
+  updateProfile(
+    @Req() req: RequestWithUser,
+    @Body() updateProfileDto: UpdateProfileDto,
+  ) {
+    return this.authService.updateProfile(req.user.id, updateProfileDto);
+  }
+
+  @Post('change-password')
+  @UseGuards(AuthGuard('jwt'))
+  changePassword(
+    @Req() req: RequestWithUser,
+    @Body() changePasswordDto: ChangePasswordDto,
+  ) {
+    return this.authService.changePassword(req.user.id, changePasswordDto);
   }
 
   @Post('refresh')

--- a/src/modules/auth/infrastructure/dto/change-password.dto.ts
+++ b/src/modules/auth/infrastructure/dto/change-password.dto.ts
@@ -1,0 +1,12 @@
+import { IsNotEmpty, IsString, MinLength } from 'class-validator';
+
+export class ChangePasswordDto {
+  @IsNotEmpty()
+  @IsString()
+  currentPassword: string;
+
+  @IsNotEmpty()
+  @IsString()
+  @MinLength(6)
+  newPassword: string;
+}

--- a/src/modules/auth/infrastructure/dto/register.dto.ts
+++ b/src/modules/auth/infrastructure/dto/register.dto.ts
@@ -4,6 +4,7 @@ import {
   IsNotEmpty,
   IsString,
   MinLength,
+  MaxLength,
 } from 'class-validator';
 import { Role } from '@prisma/client';
 
@@ -14,6 +15,8 @@ export class RegisterDto {
 
   @IsString()
   @IsNotEmpty()
+  @MinLength(5)
+  @MaxLength(50)
   name: string;
 
   @IsString()

--- a/src/modules/auth/infrastructure/dto/update-profile.dto.ts
+++ b/src/modules/auth/infrastructure/dto/update-profile.dto.ts
@@ -1,0 +1,23 @@
+import {
+  IsEmail,
+  IsOptional,
+  IsString,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
+
+export class UpdateProfileDto {
+  @IsOptional()
+  @IsString()
+  @MinLength(5)
+  @MaxLength(50)
+  name?: string;
+
+  @IsOptional()
+  @IsEmail()
+  email?: string;
+
+  @IsOptional()
+  @IsString()
+  photoUrl?: string;
+}


### PR DESCRIPTION
# feat(auth): Add profile update and password change functionality

## Description

- Implemented updateProfile method in AuthService to allow users to update their profile information, including name and email, with validation for existing email addresses.
- Added changePassword method in AuthService to enable users to change their password, including validation for current password and handling for OAuth users without passwords.
- Introduced UpdateProfileDto and ChangePasswordDto for validating incoming data in the respective methods.
- Updated AuthController to include endpoints for updating user profiles and changing passwords.

These enhancements improve user account management and security.

## Type of Changes

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🛠️ Code refactor or improvement
- [ ] 🧪 Test enhancement
- [ ] 📖 Documentation update

## Checklist

- [x] Code compiles and runs correctly
- [x] Linting and formatting rules have been followed (`eslint`, `prettier`, etc.)
- [x] Corresponding tests have been added and/or updated
- [ ] Documentation has been updated (if applicable)
- [x] The PR title is clear and uses proper formatting
- [x] Commits are clean, with descriptive messages